### PR TITLE
fix: use https instead of http for remote image resources

### DIFF
--- a/src/Modules/Main/Transformers/RemoteImageExistenceChecker.php
+++ b/src/Modules/Main/Transformers/RemoteImageExistenceChecker.php
@@ -28,7 +28,7 @@ class RemoteImageExistenceChecker extends Hybrid
     const PYRAMID = 'pyramid';
 
 
-    private $serverHost = 'http://lucascranach.org';
+    private $serverHost = 'https://lucascranach.org';
     private $remoteImageBasePath = 'imageserver/%s/%s';
     private $remoteImageDataPath = 'imageserver/%s/imageData-1.0.json';
     private $remoteImageSubDirectoryName = null;


### PR DESCRIPTION
Mit diesem PR wird `http` durch `https` für externe Bildressourcen ersetzt.