### PR TITLE
fix(remote): catch newly thrown request exeptions on 404s

### DIFF
--- a/src/Modules/Main/Transformers/RemoteDocumentExistenceChecker.php
+++ b/src/Modules/Main/Transformers/RemoteDocumentExistenceChecker.php
@@ -9,6 +9,7 @@ use CranachDigitalArchive\Importer\Interfaces\Pipeline\IProducer;
 use CranachDigitalArchive\Importer\Pipeline\Hybrid;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
 
 class RemoteDocumentExistenceChecker extends Hybrid
 {
@@ -223,11 +224,15 @@ class RemoteDocumentExistenceChecker extends Hybrid
 
     private function getRemoteDocumentDataResource(string $url): ?array
     {
-        $resp = $this->client->request('GET', $url, [
-            'headers' => [
-                'X-API-KEY' => $this->accessKey,
-            ],
-        ]);
+        try {
+            $resp = $this->client->request('GET', $url, [
+                'headers' => [
+                    'X-API-KEY' => $this->accessKey,
+                ],
+            ]);
+        } catch(RequestException $e) {
+            return null;
+        }
 
         /* @TODO: Check content-type on response */
 

--- a/src/Modules/Main/Transformers/RemoteImageExistenceChecker.php
+++ b/src/Modules/Main/Transformers/RemoteImageExistenceChecker.php
@@ -9,6 +9,7 @@ use CranachDigitalArchive\Importer\Interfaces\Pipeline\IProducer;
 use CranachDigitalArchive\Importer\Pipeline\Hybrid;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
 
 class RemoteImageExistenceChecker extends Hybrid
 {
@@ -232,11 +233,15 @@ class RemoteImageExistenceChecker extends Hybrid
 
     private function getRemoteImageDataResource(string $url): ?array
     {
-        $resp = $this->client->request('GET', $url, [
-            'headers' => [
-                'X-API-KEY' => $this->accessKey,
-            ],
-        ]);
+        try {
+            $resp = $this->client->request('GET', $url, [
+                'headers' => [
+                    'X-API-KEY' => $this->accessKey,
+                ],
+            ]);
+        } catch (RequestException $e) {
+            return null;
+        }
 
         /* @TODO: Check content-type on response */
 


### PR DESCRIPTION
Mit diesem PR wird der GET-Request, der mittels GuzzleHttp abgesetzt wird, in ein try-catch-Block gesetzt.
Aus irgendeinem Grund wird in dem Rahmen seit neustem eine RequestException geworfen, die nicht ordentlich abgefangen wurde.