### PR TITLE
fix(literatureReferences): publish literatureReferences by default

### DIFF
--- a/src/Modules/LiteratureReferences/Inflators/XML/LiteratureReferencesInflator.php
+++ b/src/Modules/LiteratureReferences/Inflators/XML/LiteratureReferencesInflator.php
@@ -177,6 +177,7 @@ class LiteratureReferencesInflator implements IInflator
         /* we derive the primary source state from the publications (after they are inflated),
             so we only need the literatureReference instances here */
         self::inflatePrimarySource($literatureReferenceCollection);
+        self::inflateIsPublished($subNode, $literatureReferenceCollection);
     }
 
 
@@ -915,6 +916,19 @@ class LiteratureReferencesInflator implements IInflator
         }
 
         $literatureReferenceCollection->setIsPrimarySource($isPrimarySource);
+    }
+
+
+    private static function inflateIsPublished(
+        SimpleXMLElement &$node,
+        LiteratureReferenceLanguageCollection $graphicCollection,
+    ): void {
+        /* all literature references are published by default */
+        $isPublished = true;
+
+        foreach ($graphicCollection as $graphic) {
+            $graphic->getMetadata()?->setIsPublished($isPublished);
+        }
     }
 
 


### PR DESCRIPTION
Mit diesem PR wird der `isPublished`-Status von Literatureinträgen standardmäßig auf `true` gesetzt, da für Literatur aktuell keine Freigabe erforderlich ist.

Das Setzen des Status wurde im Inflator angesiedelt, damit sofern irgendwann mal die Online-Freigabe auch für Literatur kommen sollte, dies ohne viel Code-Verschiebung aus dem Rohdatensatz extrahiert werden kann.