### PR TITLE
Intern

### DIFF
--- a/src/Modules/Graphics/Entities/Graphic.php
+++ b/src/Modules/Graphics/Entities/Graphic.php
@@ -60,6 +60,8 @@ class Graphic extends AbstractImagesItem implements IGraphic
     public $references = [
         'reprints' => [],
         'relatedWorks' => [],
+        'sameSheet' => [],
+        'watermark' => []
     ];
     public $additionalTextInformation = [];
     public $publications = [];
@@ -361,6 +363,36 @@ class Graphic extends AbstractImagesItem implements IGraphic
     public function getRelatedWorkReferences(): array
     {
         return $this->references['relatedWorks'];
+    }
+
+    public function addSameSheetReference(ObjectReference $reference): void
+    {
+        $this->references['sameSheet'][] = $reference;
+    }
+
+    public function setSameSheetReferences(array $references): void
+    {
+        $this->references['sameSheet'] = $references;
+    }
+
+    public function getSameSheetReferences(): array
+    {
+        return $this->references['samesheet'];
+    }
+
+    public function addWatermarkReference(ObjectReference $reference): void
+    {
+        $this->references['watermark'][] = $reference;
+    }
+
+    public function setWatermarkReferences(array $references): void
+    {
+        $this->references['watermark'] = $references;
+    }
+
+    public function getWatermarkReferences(): array
+    {
+        return $this->references['watermark'];
     }
 
     public function addAdditionalTextInformation(AdditionalTextInformation $additionalTextInformation): void

--- a/src/Modules/Graphics/Entities/GraphicLanguageCollection.php
+++ b/src/Modules/Graphics/Entities/GraphicLanguageCollection.php
@@ -403,6 +403,50 @@ class GraphicLanguageCollection extends AbstractItemLanguageCollection implement
     }
 
 
+    public function addSameSheetReference(ObjectReference $reference): void
+    {
+        foreach ($this as $graphic) {
+            $graphic->addSameSheetReference($reference);
+        }
+    }
+
+
+    public function setSameSheetReferences(array $references): void
+    {
+        foreach ($this as $graphic) {
+            $graphic->setSameSheetReferences($references);
+        }
+    }
+
+
+    public function getSameSheetReferences(): array
+    {
+        return $this->first()->getSameSheetReferences();
+    }
+
+
+    public function addWatermarkReference(ObjectReference $reference): void
+    {
+        foreach ($this as $graphic) {
+            $graphic->addWatermarkReference($reference);
+        }
+    }
+
+
+    public function setWatermarkReferences(array $references): void
+    {
+        foreach ($this as $graphic) {
+            $graphic->setWatermarkReferences($references);
+        }
+    }
+
+
+    public function getWatermarkReferences(): array
+    {
+        return $this->first()->getWatermarkReferences();
+    }
+
+
     public function addAdditionalTextInformation(AdditionalTextInformation $additionalTextInformation): void
     {
         foreach ($this as $graphic) {

--- a/src/Modules/Graphics/Inflators/XML/GraphicInflator.php
+++ b/src/Modules/Graphics/Inflators/XML/GraphicInflator.php
@@ -96,7 +96,7 @@ class GraphicInflator implements IInflator
 
     private static $referenceTypeValues = [
         'reprint' => 'Abzug A',
-        'relatedWork' => 'Teil eines Werkes',
+        'relatedWork' => 'Teil einer Serie'
     ];
 
     private static $translations = [
@@ -1099,6 +1099,7 @@ class GraphicInflator implements IInflator
                 return $reference->getText() === self::$referenceTypeValues['relatedWork'];
             }),
         );
+
 
         $graphicCollection->setReprintReferences($filteredReprintReferences);
 

--- a/src/Modules/Graphics/Inflators/XML/GraphicInflator.php
+++ b/src/Modules/Graphics/Inflators/XML/GraphicInflator.php
@@ -96,6 +96,8 @@ class GraphicInflator implements IInflator
 
     private static $referenceTypeValues = [
         'reprint' => 'Abzug A',
+        'sameSheet' => 'auf demselben Blatt',
+        'watermark' => 'identisches Wasserzeichen',
         'relatedWork' => 'Teil einer Serie'
     ];
 
@@ -1100,10 +1102,26 @@ class GraphicInflator implements IInflator
             }),
         );
 
+        $filteredSameSheetReferences = array_values(
+            array_filter($overallReferences, function ($reference) {
+                return $reference->getText() === self::$referenceTypeValues['sameSheet'];
+            }),
+        );
+
+        $filteredWatermarkReferences = array_values(
+            array_filter($overallReferences, function ($reference) {
+                return $reference->getText() === self::$referenceTypeValues['watermark'];
+            }),
+        );
+
 
         $graphicCollection->setReprintReferences($filteredReprintReferences);
 
         $graphicCollection->setRelatedWorkReferences($filteredRelatedWorkReferences);
+
+        $graphicCollection->setSameSheetReferences($filteredSameSheetReferences);
+
+        $graphicCollection->setWatermarkReferences($filteredWatermarkReferences);
     }
 
 

--- a/src/Modules/Graphics/Interfaces/IGraphic.php
+++ b/src/Modules/Graphics/Interfaces/IGraphic.php
@@ -124,6 +124,18 @@ interface IGraphic extends IImagesItem, ILocations
 
     public function getRelatedWorkReferences(): array;
 
+    public function addSameSheetReference(ObjectReference $reference): void;
+
+    public function setSameSheetReferences(array $references): void;
+
+    public function getSameSheetReferences(): array;
+
+    public function addWatermarkReference(ObjectReference $reference): void;
+
+    public function setWatermarkReferences(array $references): void;
+
+    public function getWatermarkReferences(): array;
+
     public function addAdditionalTextInformation(AdditionalTextInformation $additionalTextInformation): void;
 
     public function getAdditionalTextInformations(): array;

--- a/src/Modules/Main/Entities/ObjectReference.php
+++ b/src/Modules/Main/Entities/ObjectReference.php
@@ -25,6 +25,9 @@ class ObjectReference
         '/teil\s+eines\s+werkes/i' => 'PART_OF_WORK',
         '/gegenstück\s*\/\s*pendant/i' => 'COUNTERPART_TO',
         '/abzug/i' => 'REPRINT_OF',
+        '/Teil\s+einer\s+Serie/i' => 'PART_OF_SERIES',
+        '/auf\s+demselben\s+Blatt/i' => 'ON_SAME_SHEET',
+        '/identisches\s+Wasserzeichen/i' => 'IDENTICAL_WATERMARK'
     ];
 
     private static $remarksMappings = [


### PR DESCRIPTION
Importer wird für Cranach-Artefacts: https://github.com/lucascranach/cranach-artefacts/tree/131_Einbau_von_Related_Works_bei_Grafik_Abzuegen erweitert.
Alle Ergänzungen spielen sich bei den Referenzen ab.
Beim virtuellen Datensatz ist "Teil einer Serie" hinzugekommen und löst "Teil eines Werkes" ab.
Beim reellen Datensatz sind "Identisches Wasserzeichen" und "auf dem selben Blatt" hinzugekommen.