### PR TITLE
add compontent_parts to filter path

### DIFF
--- a/src/Modules/Filters/Transformers/ArtefactNumericalSorter.php
+++ b/src/Modules/Filters/Transformers/ArtefactNumericalSorter.php
@@ -10,6 +10,7 @@ use Error;
 class ArtefactNumericalSorter extends Hybrid
 {
     private $paths = [
+        ['component_parts']
     ];
 
     private $recursivePaths = [


### PR DESCRIPTION
Habe die "component_parts" in den Sortierer hinzugefügt. Damit landet das Fragment hinter dem Retabelaufsatz.
https://github.com/lucascranach/importer/issues/38

> Noch eine Kleinigkeit: Könntest du bei dem Filter Bestandteile bitte die Reihenfolge ändern und den Retabelauszug vor das Fragment setzen? Das kann auch direkt ans Frontend.