### PR TITLE
create Transformer ReferenceDivider for Paintings

### DIFF
--- a/src/Constructions/Default/Paintings.php
+++ b/src/Constructions/Default/Paintings.php
@@ -12,6 +12,7 @@ use CranachDigitalArchive\Importer\Modules\Paintings\Loaders\XML\PaintingsPreLoa
 use CranachDigitalArchive\Importer\Modules\Paintings\Collectors\ReferencesCollector;
 use CranachDigitalArchive\Importer\Modules\Paintings\Loaders\XML\PaintingsLoader;
 use CranachDigitalArchive\Importer\Modules\Paintings\Transformers\ExtenderWithReferences;
+use CranachDigitalArchive\Importer\Modules\Paintings\Transformers\ReferenceDivider;
 use CranachDigitalArchive\Importer\Modules\Paintings\Transformers\ExtenderWithRestorations;
 use CranachDigitalArchive\Importer\Modules\Paintings\Transformers\ExtenderWithIds;
 use CranachDigitalArchive\Importer\Modules\Paintings\Transformers\MetadataFiller;
@@ -68,6 +69,7 @@ final class Paintings
         $this->loader->pipeline(
             (!$parameters->getKeepSoftDeletedAretefacts()) ? SkipSoftDeletedArtefactGate::new('Paintings'): null,
             ExtenderWithReferences::new($this->paintingsReferencesCollector),
+            ReferenceDivider::new($this->paintingsReferencesCollector),
             $paintingsRemoteDocumentExistenceChecker,
             $paintingsRemoteImageExistenceChecker,
             ExtenderWithRestorations::new($paintingsRestoration->getMemoryExporter()),

--- a/src/Modules/Paintings/Transformers/ReferenceDivider.php
+++ b/src/Modules/Paintings/Transformers/ReferenceDivider.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace CranachDigitalArchive\Importer\Modules\Paintings\Transformers;
+
+use CranachDigitalArchive\Importer\Interfaces\Pipeline\IProducer;
+use CranachDigitalArchive\Importer\Modules\Paintings\Collectors\ReferencesCollector;
+use CranachDigitalArchive\Importer\Modules\Paintings\Entities\PaintingLanguageCollection;
+use CranachDigitalArchive\Importer\Pipeline\Hybrid;
+use Error;
+
+class ReferenceDivider extends Hybrid
+{
+    private $referenceCollector;
+
+    private function __construct(ReferencesCollector $referencesCollector)
+    {
+        $this->referenceCollector = $referencesCollector;
+    }
+
+
+    public static function new(ReferencesCollector $referencesCollector): self
+    {
+        return new self($referencesCollector);
+    }
+
+
+
+    public function handleItem($item): bool
+    {
+        if (!($item instanceof PaintingLanguageCollection)) {
+            throw new Error('Pushed item is not of expected class \'PaintingLanguageCollection\'');
+        }
+
+        $references = [
+            "relatedInContentTo"=>[],
+            "similarTo"=>[],
+            "belongsTo"=>[],
+            "partOfWork"=>[],
+            "counterpartTo"=>[],
+            "graphic"=>[]
+        ];
+
+        foreach ($item as $subItem) {
+            $subItemReferences = $subItem->getReferences();
+            foreach ($subItemReferences as $referenceItem) {
+                if ($referenceItem->kind === 'RELATED_IN_CONTENT_TO') {
+                    $references['relatedInContentTo'][] = $referenceItem;
+                } elseif ($referenceItem->kind === 'SIMILAR_TO') {
+                    $references['similarTo'][] = $referenceItem;
+                } elseif ($referenceItem->kind === 'BELONGS_TO') {
+                    $references['belongsTo'][] = $referenceItem;
+                } elseif ($referenceItem->kind === 'PART_OF_WORK') {
+                    $references['partOfWork'][] = $referenceItem;
+                } elseif ($referenceItem->kind === 'COUNTERPART_TO') {
+                    $references['counterpartTo'][] = $referenceItem;
+                } elseif ($referenceItem->kind === 'GRAPHIC') {
+                    $references['graphic'][] = $referenceItem;
+                }
+            }
+            $subItem->setReferences($references);
+        }
+
+        $this->next($item);
+        return true;
+    }
+
+
+    /**
+     * @return void
+     */
+    public function done(IProducer $producer)
+    {
+        parent::done($producer);
+    }
+}


### PR DESCRIPTION
Hier werden die Referenzen der Paintings aufgeteilt, sodass nicht mehr alles nur in einem Array erscheint.
Referenzen sehen dann wie folgt aus:
`
references = [
            "relatedInContentTo" = {},
            "similarTo"= {},
            "belongsTo"= {},
            "partOfWork"= {},
            "counterpartTo"= {},
            "graphic"= {}
        ]
`

Cranach Artefacts müssen dementsprechend angepasst werden.
Gemälde und Grafiken haben jetzt die gleiche Struktur.